### PR TITLE
Move requirements into requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ $ git clone https://github.com/R4yGM/AsciiPy
 ## Depencies
 this tool has dependency, and to install them you have to run 
 ```shell
-$ chmod +x requirements.sh
-$ ./requirements.sh
+$ pip install -r requirements.txt
 ```
 ## Asciify in your python script
 to start asciifying in your script you have to import the module

--- a/requirements.sh
+++ b/requirements.sh
@@ -1,3 +1,0 @@
-echo AsciiPy v0.1 author R4yan: dependency install
-echo ---------------------------------------------
-pip install opencv-python requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+opencv-python==4.1.1.26
+requests==2.22.0


### PR DESCRIPTION
This change would remove the `requirements.sh` script and instead utilise pip's support for [installing requirements from a file](https://pip.readthedocs.io/en/1.1/requirements.html).
For now I have put version numbers on the dependencies to try and ensure consistent installations, however you may wish to remove these and always install the latest version of the packages as you were before.
Please let me know your thoughts, and thanks for the cool project!